### PR TITLE
fixing offset error

### DIFF
--- a/src/internal.jl
+++ b/src/internal.jl
@@ -10,7 +10,7 @@ get_value
 
 get_value(optparam::OptimizationParameter) = optparam.x0
 get_value(optparam::OptimizationParameter{<:Any, <:Any, <:Any, <:Any, false}, x) = optparam.x0
-get_value(optparam::OptimizationParameter{<:Any, <:Number, <:Any, <:Any, true}, x) = x[1]/optparam.scaling + design_variable_offset(optparam.lb, optparam.ub)
+get_value(optparam::OptimizationParameter{<:Any, <:Number, <:Any, <:Any, true}, x) = x[1]/optparam.scaling - design_variable_offset(optparam.lb, optparam.ub)
 
 function get_value(optparam::OptimizationParameter{S, <:AbstractArray{<:Any, N}, <:Any, <:Any, true}, x) where {S, N}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,8 +123,14 @@ using Test
     x0, lb, ub = assemble_input(nt)
     x0, lb, ub = assemble_input(dict)
 
-    #extract parameter values (still need proper test here)
+    # extract parameter values (still need proper test here)
     parameters = get_values(nt, x0)
     parameters = get_values(dict, x0)
+
+    # test that offset works properly
+    lb = 0
+    ub = 10
+    optparam = OptimizationParameter(0; lb=lb, ub=ub, dv=true)
+    @test OptimizationParameters.get_value(optparam, 0) == (lb + ub)/2
 
 end


### PR DESCRIPTION
When using `get_values(optparam::OptimizationParameter, x)`, I was getting negative values of what I should have been getting. I think this edit fixes that by subtracting the offset instead of adding it.